### PR TITLE
Fixed crashes when launching release build...

### DIFF
--- a/Libraries/AIinterp/Sources/AI2C.cpp
+++ b/Libraries/AIinterp/Sources/AI2C.cpp
@@ -118,11 +118,18 @@ extern "C"
 
 class AI_tdUser
 {
-public :
-    AI_tdUser() {h_User = 0; s_CallBackName = 0;}
-    BIG_KEY h_User;
-    char *s_CallBackName;
-    bool operator == (const AI_tdUser _sUser) {return (_sUser.h_User == h_User) && (0 == strcmp(_sUser.s_CallBackName,s_CallBackName));}
+public:
+	AI_tdUser()
+	{
+		h_User         = 0;
+		s_CallBackName = 0;
+	}
+	BIG_KEY h_User;
+	char *s_CallBackName;
+	bool operator==( const AI_tdUser _sUser )
+	{
+		return ( _sUser.h_User == h_User ) && ( ( s_CallBackName != nullptr && _sUser.s_CallBackName != nullptr && ( 0 == strcmp( _sUser.s_CallBackName, s_CallBackName ) ) ) || s_CallBackName == _sUser.s_CallBackName );
+	}
 };
 
 

--- a/Libraries/SDK/Sources/BIGfiles/LOAding/LOAdefs.c
+++ b/Libraries/SDK/Sources/BIGfiles/LOAding/LOAdefs.c
@@ -541,7 +541,7 @@ void LOA_PrintRefToLog()
 #ifdef _DEBUG
         AI_vAddKeyDependency(_ul_Key,LOA_gul_CurrentKey,_s_CallbackName);
 #else // _DEBUG
-        AI_vAddKeyDependency(_ul_Key,LOA_gul_CurrentKey,"");
+        AI_vAddKeyDependency(_ul_Key,LOA_gul_CurrentKey,NULL);
 #endif // _DEBUG
 
 #endif // ACTIVE_EDITORS


### PR DESCRIPTION
This is a bit of a bodge at the moment. ODE will just use the standard new/delete routes going forward for release build. Things will be better once changes under mem-overhaul are done.